### PR TITLE
fix: Missing 'tidydns' provider in enum validation list

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -417,6 +417,7 @@ var providerNames = []string{
 	"rfc2136",
 	"scaleway",
 	"skydns",
+	"tidydns",
 	"transip",
 	"webhook",
 }


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
